### PR TITLE
Update runtime to 6.9, update components, add x-checker-data

### DIFF
--- a/space.nouspiro.tenmon.json
+++ b/space.nouspiro.tenmon.json
@@ -1,124 +1,147 @@
 {
-	"id": "space.nouspiro.tenmon",
-	"runtime": "org.kde.Platform",
-	"runtime-version": "6.7",
-	"sdk": "org.kde.Sdk",
-	"command": "tenmon",
-	"cleanup": [
-		"/include",
-		"*.a",
-		"*.la",
-		"*.cmake"
-	],
-	"finish-args":
-	[
-		"--share=ipc",
-		"--share=network",
-		"--socket=fallback-x11",
-		"--socket=wayland",
-		"--device=dri",
-		"--filesystem=host:rw",
-		"--filesystem=xdg-run/gvfs:ro",
-		"--talk-name=org.freedesktop.FileManager1"
-	],
-	"modules": [
-		{
-			"name": "libgsl",
-			"buildsystem": "autotools",
-			"cleanup": ["/bin"],
-			"sources": [
-				{
-					"type": "archive",
-					"url": "https://quantum-mirror.hu/mirrors/pub/gnu/gsl/gsl-2.7.1.tar.gz",
-					"sha256": "dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b"
-				}
-			]
-		},
-		{
-			"name": "cfitsio",
-			"buildsystem": "cmake-ninja",
-			"builddir": true,
-			"cleanup": [
-				"/bin"
-			],
-			"config-opts": [
-				"-DCMAKE_BUILD_TYPE=Release",
-				"-DUSE_PTHREADS=ON"
-			],
-			"sources": [
-				{
-					"type": "archive",
-					"disable-http-decompression": true,
-					"url": "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.4.0.tar.gz",
-					"sha256": "95900cf95ae760839e7cb9678a7b2fad0858d6ac12234f934bd1cb6bfc246ba9"
-				}
-			]
-		},
-		{
-			"name": "libraw",
-			"buildsystem": "autotools",
-			"cleanup": [
-				"/bin"
-			],
-			"sources": [
-				{
-					"type": "archive",
-					"url": "https://www.libraw.org/data/LibRaw-0.21.1.tar.gz",
-					"sha256": "630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd"
-				},
-				{
-					"type": "shell",
-					"commands": ["autoreconf -f -i"]
-				}
-			]
-		},
-		{
-			"name": "wcs",
-			"buildsystem": "autotools",
-			"cleanup": [
-				"/bin"
-			],
-			"sources": [
-				{
-					"type": "archive",
-					"url": "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-8.2.2.tar.bz2",
-					"sha256": "6298220ae817f4e5522643ac4c3da2623be70a3484b1a4f37060bee3e4bd7833"
-				}
-			]
-		},
-		{
-			"name": "stellarsolver",
-			"buildsystem": "cmake-ninja",
-			"config-opts": [
-				"-DCMAKE_BUILD_TYPE=Release",
-				"-DUSE_QT5=OFF"
-			],
-			"sources": [
-				{
-					"type": "git",
-					"url": "https://github.com/rlancaste/stellarsolver.git",
-					"commit": "0e4db32caa2d98a9a4ff2a2df765c45e9539ba93"
-				}
-			]
-		},
-		{
-			"name": "tenmon",
-			"buildsystem": "cmake-ninja",
-			"config-opts": [
-				"-DCMAKE_BUILD_TYPE=Release",
-				"-DRELEASE_BUILD=ON",
-				"-DFLATPAK=ON",
-				"-DUSE_BUNDLED_LIBS=ON",
-				"-DUSE_BUNDLED_ZLIB=OFF"
-			],
-			"sources": [
-				{
-					"type": "git", 
-					"url": "https://gitea.nouspiro.space/nou/tenmon.git",
-					"tag": "20250429",
-					"commit": "c6bc792ff79adec2ab8fa91aabc8202afdd5ba42"
-				}
-			]
-		}
-	]
+    "id": "space.nouspiro.tenmon",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.9",
+    "sdk": "org.kde.Sdk",
+    "command": "tenmon",
+    "cleanup": [
+        "/include",
+        "*.a",
+        "*.la",
+        "*.cmake"
+    ],
+    "finish-args": [
+        "--share=ipc",
+        "--share=network",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host:rw",
+        "--filesystem=xdg-run/gvfs:ro",
+        "--talk-name=org.freedesktop.FileManager1"
+    ],
+    "modules": [
+        {
+            "name": "libgsl",
+            "cleanup": [
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://quantum-mirror.hu/mirrors/pub/gnu/gsl/gsl-2.8.tar.gz",
+                    "sha256": "6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1267,
+                        "url-template": "https://quantum-mirror.hu/mirrors/pub/gnu/gsl/gsl-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "cfitsio",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "cleanup": [
+                "/bin"
+            ],
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DUSE_PTHREADS=ON"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "disable-http-decompression": true,
+                    "url": "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.6.2.tar.gz",
+                    "sha256": "66fd078cc0bea896b0d44b120d46d6805421a5361d3a5ad84d9f397b1b5de2cb",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 270,
+                        "url-template": "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libraw",
+            "cleanup": [
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.libraw.org/data/LibRaw-0.21.4.tar.gz",
+                    "sha256": "6be43f19397e43214ff56aab056bf3ff4925ca14012ce5a1538a172406a09e63",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1709,
+                        "url-template": "https://www.libraw.org/data/LibRaw-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "wcslib",
+            "cleanup": [
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-8.4.tar.bz2",
+                    "sha256": "960b844426d14a8b53cdeed78258aa9288cded99a7732c0667c64fa6a50126dc",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 7693,
+                        "url-template": "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-$version.tar.bz2"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "stellarsolver",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DUSE_QT5=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/rlancaste/stellarsolver.git",
+                    "tag": "2.7",
+                    "commit": "5902126c7a0ac01877c29f1189bda23f0837cf58",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "tenmon",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DRELEASE_BUILD=ON",
+                "-DFLATPAK=ON",
+                "-DUSE_BUNDLED_LIBS=ON",
+                "-DUSE_BUNDLED_ZLIB=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitea.nouspiro.space/nou/tenmon.git",
+                    "tag": "20250429",
+                    "commit": "c6bc792ff79adec2ab8fa91aabc8202afdd5ba42",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d]+)$"
+                    }
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
I am sorry the diff is so difficult to read. I manually ran `flatpak-external-data-checker` to update the modules, and it changes JSON formatting to indentation by four spaces…

- Update runtime
- Add x-checker-data to automate module updates
- Update `libgsl` from 2.7 to 2.8
- Update `cfitsio` from 4.4.0 to 4.6.2
- Update `libraw` from 0.21.1 to 0.21.4
- Update `wcslib` from 8.2.2 to 8.4
- Update `stellarsolver` from a 2024 commit to latest 2.7